### PR TITLE
Remove remappings.txt

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,6 +19,14 @@ gas_reports_ignore = [
     "ForTest_JBTiered721DelegateStore",
     "JBTiered721DelegateStore",
 ]
+remappings = [
+    "@jbx-protocol=node_modules/@jbx-protocol/",
+    "@openzeppelin=node_modules/@openzeppelin/",
+    "@paulrberg=node_modules/@paulrberg/",
+    "prb-math=node_modules/prb-math/",
+    "ds-test/=lib/forge-std/lib/ds-test/src/",
+    "forge-std/=lib/forge-std/src/",
+]
 
 optimizer_runs = 200
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,6 +1,0 @@
-@jbx-protocol=node_modules/@jbx-protocol/
-@openzeppelin=node_modules/@openzeppelin/
-@paulrberg=node_modules/@paulrberg/
-prb-math=node_modules/prb-math/
-ds-test/=lib/forge-std/lib/ds-test/src/
-forge-std/=lib/forge-std/src/


### PR DESCRIPTION
Fix breaking import when using this repo as submodule while in a non-npm project (ie not resolving the node_packages)