### PR TITLE
royalty routes to the project's treasury by default

### DIFF
--- a/contracts/interfaces/IJBTiered721Delegate.sol
+++ b/contracts/interfaces/IJBTiered721Delegate.sol
@@ -84,4 +84,6 @@ interface IJBTiered721Delegate is IJB721Delegate {
     IJBTiered721DelegateStore _store,
     JBTiered721Flags memory _flags
   ) external;
+
+  receive() external payable;
 }


### PR DESCRIPTION
If no royalty beneficiary is set, royalties will be routed to the delegate itself, which will route the payment to the project's treasury to which the collection belongs, and issue tokens to the tx.origin -- usually the buyer or seller of the NFT.