### PR TITLE
fix: empty tiers array should be length 0

### DIFF
--- a/contracts/JBTiered721DelegateStore.sol
+++ b/contracts/JBTiered721DelegateStore.sol
@@ -147,6 +147,9 @@ contract JBTiered721DelegateStore is IJBTiered721DelegateStore {
         // Keep a reference to the last tier ID.
         uint256 _lastTierId = _lastSortedTierIdOf(_nft);
 
+        // Retuen an empty array if there are no tiers.
+        if (_lastTierId == 0) return _tiers;
+
         // Initialize an array with the appropriate length.
         _tiers = new JB721Tier[](_size);
 


### PR DESCRIPTION
Fix a small bug in tiersOf: if there are no tiers yet, an array with empty tiers (ie '0' in every fields) of length _size is returned.

This fix returns an array of length 0, bypassing the array 0-initialization altogether.

This is only for delegate without *initialized* tiers, not the one with only *removed* tiers.